### PR TITLE
Implement GET /repo?uri=%s endpoint

### DIFF
--- a/repository/repo.go
+++ b/repository/repo.go
@@ -74,6 +74,10 @@ func (r *Repo) GetURI() string {
 	return r.repoURI
 }
 
+func (r *Repo) GetOptions() *RepoOptions {
+	return r.options
+}
+
 func (r *Repo) GetFileInfos(path string, recursive bool) (infoMap map[string]os.FileInfo, err error) {
 
 	if path == "" {

--- a/server/operator/operator.go
+++ b/server/operator/operator.go
@@ -88,6 +88,10 @@ func (op *Operator) GetRepos() (items []string, err error) {
 	return op.store.FindAll()
 }
 
+func (op *Operator) GetRepo(repoURI string) (repo *repository.Repo, err error) {
+	return op.rc.Get(repoURI)
+}
+
 func (op *Operator) AddRepo(options *repository.RepoOptions) error {
 
 	uri := options.GetNormalizedURI()

--- a/server/rest/rest.go
+++ b/server/rest/rest.go
@@ -67,6 +67,20 @@ func setupRouter(host string, port int, op *operator.Operator) *gin.Engine {
 		context.Status(200)
 	})
 
+	v1.GET("/repo", func(context *gin.Context) {
+		repoURI := context.Query("uri")
+
+		repo, err := op.GetRepo(repoURI)
+
+		if err != nil {
+			context.JSON(500, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+		context.JSON(200, repo.GetOptions())
+	})
+
 	v1.GET("/search", func(context *gin.Context) {
 		q := context.Query("q")
 		result, err := op.Search(q)

--- a/server/rest/rest_test.go
+++ b/server/rest/rest_test.go
@@ -71,6 +71,15 @@ func TestRest(t *testing.T) {
 
 	assert.Equal(t, 200, resp.Code)
 
+	// Test get repo
+	req, _ = http.NewRequest("GET", fmt.Sprintf("/v1/repo?uri=%s", mockRepoOptions.GetNormalizedURI()), nil)
+	resp = doRequest(router, req)
+
+	var respRepoOptions repository.RepoOptions
+	_ = json.Unmarshal([]byte(resp.Body.String()), &respRepoOptions)
+
+	assert.Equal(t, *mockRepoOptions, respRepoOptions)
+
 	// Test get repos
 	req, _ = http.NewRequest("GET", "/v1/repos", nil)
 	resp = doRequest(router, req)

--- a/server/rest/rest_test.go
+++ b/server/rest/rest_test.go
@@ -75,10 +75,10 @@ func TestRest(t *testing.T) {
 	req, _ = http.NewRequest("GET", fmt.Sprintf("/v1/repo?uri=%s", mockRepoOptions.GetNormalizedURI()), nil)
 	resp = doRequest(router, req)
 
-	var respRepoOptions repository.RepoOptions
+	var respRepoOptions *repository.RepoOptions
 	_ = json.Unmarshal([]byte(resp.Body.String()), &respRepoOptions)
 
-	assert.Equal(t, *mockRepoOptions, respRepoOptions)
+	assert.Equal(t, mockRepoOptions, respRepoOptions)
 
 	// Test get repos
 	req, _ = http.NewRequest("GET", "/v1/repos", nil)


### PR DESCRIPTION
This PR implements the GET /repo?uri=%s endpoint with its tests regarding the issue #3